### PR TITLE
chore: drop support for Python 3.6, format with Black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length=120
+max-line-length = 120

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [Justintime50]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.6", "3.7", "3.8", "3.9"]
+        pythonversion: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.4.0 (2021-09-20)
+
+* Drops support for Python 3.6
+* Swaps `mock` library for builtin `unittest.mock` library
+* Formats entire project with `Black`
+
 ## v2.3.0 (2021-05-31)
 
 * Pin dependencies

--- a/pullbug/cli.py
+++ b/pullbug/cli.py
@@ -18,10 +18,9 @@ ROCKET_CHAT_URL = os.getenv('ROCKET_CHAT_URL')
 LOGGER = logging.getLogger(__name__)
 
 
-class PullBugCLI():
+class PullBugCLI:
     def __init__(self):
-        """Initiate CLI args.
-        """
+        """Initiate CLI args."""
         parser = argparse.ArgumentParser(
             description='Get bugged via Slack or RocketChat to merge your GitHub pull requests or GitLab merge requests.'  # noqa
         )
@@ -31,7 +30,7 @@ class PullBugCLI():
             required=False,
             action='store_true',
             default=False,
-            help='Get bugged about pull requests from GitHub.'
+            help='Get bugged about pull requests from GitHub.',
         )
         parser.add_argument(
             '-gl',
@@ -39,7 +38,7 @@ class PullBugCLI():
             required=False,
             action='store_true',
             default=False,
-            help='Get bugged about merge requests from GitLab.'
+            help='Get bugged about merge requests from GitLab.',
         )
         parser.add_argument(
             '-d',
@@ -47,7 +46,7 @@ class PullBugCLI():
             required=False,
             action='store_true',
             default=False,
-            help='Send Pullbug messages to Discord.'
+            help='Send Pullbug messages to Discord.',
         )
         parser.add_argument(
             '-s',
@@ -55,7 +54,7 @@ class PullBugCLI():
             required=False,
             action='store_true',
             default=False,
-            help='Send Pullbug messages to Slack.'
+            help='Send Pullbug messages to Slack.',
         )
         parser.add_argument(
             '-rc',
@@ -63,7 +62,7 @@ class PullBugCLI():
             required=False,
             action='store_true',
             default=False,
-            help='Send Pullbug messages to Rocket.Chat.'
+            help='Send Pullbug messages to Rocket.Chat.',
         )
         parser.add_argument(
             '-w',
@@ -71,7 +70,7 @@ class PullBugCLI():
             required=False,
             action='store_true',
             default=False,
-            help='Include "Work in Progress" pull or merge requests.'
+            help='Include "Work in Progress" pull or merge requests.',
         )
         parser.add_argument(
             '-gho',
@@ -79,7 +78,7 @@ class PullBugCLI():
             required=False,
             type=str,
             default=None,
-            help='The GitHub owner to retrieve pull requests from (can be a user or organization).'
+            help='The GitHub owner to retrieve pull requests from (can be a user or organization).',
         )
         parser.add_argument(
             '-ghs',
@@ -88,7 +87,7 @@ class PullBugCLI():
             type=str,
             default='open',
             choices=['open', 'closed', 'all'],
-            help='The GitHub state to retrieve pull requests with.'
+            help='The GitHub state to retrieve pull requests with.',
         )
         parser.add_argument(
             '-ghc',
@@ -97,7 +96,7 @@ class PullBugCLI():
             type=str,
             default='orgs',
             choices=['orgs', 'users'],
-            help='The GitHub context to retrieve pull requests with.'
+            help='The GitHub context to retrieve pull requests with.',
         )
         parser.add_argument(
             '-glst',
@@ -106,7 +105,7 @@ class PullBugCLI():
             type=str,
             default='opened',
             choices=['opened', 'closed', 'locked', 'merged'],
-            help='The GitLab state to retrieve merge requests with.'
+            help='The GitLab state to retrieve merge requests with.',
         )
         parser.add_argument(
             '-glsc',
@@ -115,13 +114,12 @@ class PullBugCLI():
             type=str,
             default='all',
             choices=['all', 'created_by_me', 'assigned_to_me'],
-            help='The GitLab state to retrieve pull requests with.'
+            help='The GitLab state to retrieve pull requests with.',
         )
         parser.parse_args(namespace=self)
 
     def run(self):
-        """Send command line args to the main run function.
-        """
+        """Send command line args to the main run function."""
         PullBug.run(
             github=self.github,
             gitlab=self.gitlab,
@@ -137,12 +135,23 @@ class PullBugCLI():
         )
 
 
-class PullBug():
+class PullBug:
     @classmethod
-    def run(cls, github, gitlab, discord, slack, rocketchat, wip, github_owner,
-            github_state, github_context, gitlab_state, gitlab_scope):
-        """Run Pullbug based on the configuration.
-        """
+    def run(
+        cls,
+        github,
+        gitlab,
+        discord,
+        slack,
+        rocketchat,
+        wip,
+        github_owner,
+        github_state,
+        github_context,
+        gitlab_state,
+        gitlab_scope,
+    ):
+        """Run Pullbug based on the configuration."""
         PullBugLogger._setup_logging(LOGGER)
         LOGGER.info('Running Pullbug...')
         load_dotenv()

--- a/pullbug/gitlab_bug.py
+++ b/pullbug/gitlab_bug.py
@@ -10,12 +10,12 @@ GITLAB_API_KEY = os.getenv('GITLAB_API_KEY')
 GITLAB_API_URL = os.getenv('GITLAB_API_URL', 'https://gitlab.com/api/v4')
 IGNORE_WIP = os.getenv('IGNORE_WIP')
 GITLAB_HEADERS = {
-    'authorization': f'Bearer {GITLAB_API_KEY}'
+    'authorization': f'Bearer {GITLAB_API_KEY}',
 }
 LOGGER = logging.getLogger(__name__)
 
 
-class GitlabBug():
+class GitlabBug:
     @classmethod
     def run(cls, gitlab_scope='all', gitlab_state='opened', wip=False, discord=False, slack=False, rocketchat=False):
         """Run the logic to get MR's from GitLab and
@@ -43,25 +43,25 @@ class GitlabBug():
 
     @classmethod
     def get_merge_requests(cls, gitlab_scope, gitlab_state):
-        """Get all repos of the GITLAB_API_URL.
-        """
+        """Get all repos of the GITLAB_API_URL."""
         LOGGER.info('Bugging GitLab for merge requests...')
         try:
             response = requests.get(
                 f"{GITLAB_API_URL}/merge_requests?scope={gitlab_scope}&state={gitlab_state}&per_page=100",
-                headers=GITLAB_HEADERS
+                headers=GITLAB_HEADERS,
             )
             LOGGER.debug(response.text)
             LOGGER.info('GitLab merge requests retrieved!')
             if 'does not have a valid value' in response.text:
-                error = f'Could not retrieve GitLab merge requests due to bad parameter: {gitlab_scope} | {gitlab_state}.'  # noqa
+                error = (
+                    f'Could not retrieve GitLab merge requests due to bad parameter: {gitlab_scope} | {gitlab_state}.'
+                )
                 LOGGER.error(error)
                 raise ValueError(error)
         except requests.exceptions.RequestException as response_error:
-            LOGGER.error(
-                f'Could not retrieve GitLab merge requests: {response_error}'
-            )
+            LOGGER.error(f'Could not retrieve GitLab merge requests: {response_error}')
             raise requests.exceptions.RequestException(response_error)
+
         return response.json()
 
     @classmethod
@@ -80,4 +80,5 @@ class GitlabBug():
                 message, discord_message = Messages.prepare_gitlab_message(merge_request, discord, slack, rocketchat)
                 message_array.append(message)
                 discord_message_array.append(discord_message)
+
         return message_array, discord_message_array

--- a/pullbug/logger.py
+++ b/pullbug/logger.py
@@ -2,29 +2,24 @@ import logging
 import logging.handlers
 import os
 
-PULLBUG_LOCATION = os.path.expanduser(
-    os.getenv('PULLBUG_LOCATION', '~/pullbug')
-)
+PULLBUG_LOCATION = os.path.expanduser(os.getenv('PULLBUG_LOCATION', '~/pullbug'))
 LOG_PATH = os.path.join(PULLBUG_LOCATION, 'logs')
 LOG_FILE = os.path.join(LOG_PATH, 'pullbug.log')
 
 
-class PullBugLogger():
+class PullBugLogger:
     @classmethod
     def _setup_logging(cls, logger):
-        """Setup project logging (to console and log file).
-        """
+        """Setup project logging (to console and log file)."""
         if not os.path.exists(LOG_PATH):
             os.makedirs(LOG_PATH)
         logger.setLevel(logging.INFO)
         handler = logging.handlers.RotatingFileHandler(
             LOG_FILE,
             maxBytes=200000,
-            backupCount=5
+            backupCount=5,
         )
-        formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s"
-        )
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
         handler.setFormatter(formatter)
         logger.addHandler(logging.StreamHandler())
         logger.addHandler(handler)

--- a/pullbug/messages.py
+++ b/pullbug/messages.py
@@ -14,7 +14,7 @@ GITLAB_API_URL = os.getenv('GITLAB_API_URL', 'https://gitlab.com/api/v4')
 LOGGER = logging.getLogger(__name__)
 
 
-class Messages():
+class Messages:
     @classmethod
     def send_discord_message(cls, message):
         """Send a Discord message.
@@ -67,14 +67,12 @@ class Messages():
         try:
             slack_client.chat_postMessage(
                 channel=SLACK_CHANNEL,
-                text=slack_message
+                text=slack_message,
             )
             LOGGER.info('Slack message sent!')
         except slack.errors.SlackApiError as slack_error:
             LOGGER.error(f'Could not send Slack message: {slack_error}')
-            raise slack.errors.SlackApiError(
-                slack_error.response["ok"], slack_error.response['error']
-            )
+            raise slack.errors.SlackApiError(slack_error.response["ok"], slack_error.response['error'])
 
     @classmethod
     def prepare_github_message(cls, pull_request, discord, slack, rocketchat):
@@ -97,8 +95,11 @@ class Messages():
         else:
             users = 'NA'
 
-        description = (pull_request.get('body')[:description_max_length] +
-                       '...') if len(pull_request['body']) > description_max_length else pull_request.get('body')
+        description = (
+            (pull_request.get('body')[:description_max_length] + '...')
+            if len(pull_request['body']) > description_max_length
+            else pull_request.get('body')
+        )
         message = (
             f"\n:arrow_heading_up: *Pull Request:* <{pull_request['html_url']}|{pull_request['title']}>"
             f"\n*Repo:* <{pull_request['base']['repo']['html_url']}|{pull_request['base']['repo']['name']}>"
@@ -134,8 +135,11 @@ class Messages():
         else:
             users = 'NA'
 
-        description = (merge_request.get('description')[:description_max_length] +
-                       '...') if len(merge_request['description']) > description_max_length else merge_request.get('description')  # noqa
+        description = (
+            (merge_request.get('description')[:description_max_length] + '...')
+            if len(merge_request['description']) > description_max_length
+            else merge_request.get('description')
+        )
         message = (
             f"\n:arrow_heading_up: *Merge Request:* <{merge_request['web_url']}|{merge_request['title']}>"
             f"\n*Repo:* <{GITLAB_API_URL}/{re_match['group_name']}/{re_match['repo_name']}|{re_match['repo_name']}>"

--- a/setup.py
+++ b/setup.py
@@ -6,21 +6,22 @@ with open('README.md', 'r') as fh:
 REQUIREMENTS = [
     'requests == 2.*',
     'slackclient == 2.*',
-    'python-dotenv == 0.17.*'
+    'python-dotenv == 0.19.*',  # TODO: Remove once we convert env variables to CLI args
 ]
 
 DEV_REQUIREMENTS = [
     'coveralls == 3.*',
     'flake8',
-    'mock == 4.*',
     'pytest == 6.*',
     'pytest-cov == 2.*',
 ]
 
 setuptools.setup(
     name='pullbug',
-    version='2.3.0',
-    description='Get bugged via Discord, Slack, or RocketChat to merge your GitHub pull requests or GitLab merge requests.',  # noqa
+    version='2.4.0',
+    description=(
+        'Get bugged via Discord, Slack, or RocketChat to merge your GitHub pull requests or GitLab merge requests.'
+    ),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='http://github.com/justintime50/pull-bug',
@@ -34,12 +35,12 @@ setuptools.setup(
     ],
     install_requires=REQUIREMENTS,
     extras_require={
-        'dev': DEV_REQUIREMENTS
+        'dev': DEV_REQUIREMENTS,
     },
     entry_points={
         'console_scripts': [
-            'pullbug=pullbug.cli:main'
-        ]
+            'pullbug=pullbug.cli:main',
+        ],
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,19 +1,18 @@
-import mock
+from unittest.mock import patch
+
 import pytest
 from pullbug.cli import PullBug
 
 
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.LOGGER')
 def test_throw_missing_error(mock_logger):
     with pytest.raises(ValueError):
         PullBug.throw_missing_error('GITHUB_TOKEN')
 
-    mock_logger.critical.assert_called_once_with(
-        'No GITHUB_TOKEN set. Please correct and try again.'
-    )
+    mock_logger.critical.assert_called_once_with('No GITHUB_TOKEN set. Please correct and try again.')
 
 
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_github_or_gitlab(mock_logger):
     with pytest.raises(ValueError):
         PullBug.run_missing_checks(False, False, False, False, False)
@@ -23,10 +22,10 @@ def test_run_missing_checks_no_github_or_gitlab(mock_logger):
     )
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', '123')
-@mock.patch('pullbug.cli.PullBug.run_missing_checks')
-@mock.patch('pullbug.github_bug.GithubBug.run')
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', '123')
+@patch('pullbug.cli.PullBug.run_missing_checks')
+@patch('pullbug.github_bug.GithubBug.run')
+@patch('pullbug.cli.LOGGER')
 def test_run_with_github_arg(mock_logger, mock_github, mock_missing_checks):
     PullBug.run(True, False, False, False, False, False, 'mock-owner', 'open', 'orgs', 'opened', 'all')
 
@@ -35,10 +34,10 @@ def test_run_with_github_arg(mock_logger, mock_github, mock_missing_checks):
     mock_logger.info.assert_called()
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', '123')
-@mock.patch('pullbug.cli.PullBug.run_missing_checks')
-@mock.patch('pullbug.gitlab_bug.GitlabBug.run')
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', '123')
+@patch('pullbug.cli.PullBug.run_missing_checks')
+@patch('pullbug.gitlab_bug.GitlabBug.run')
+@patch('pullbug.cli.LOGGER')
 def test_run_with_gitlab_arg(mock_logger, mock_gitlab, mock_missing_checks):
     PullBug.run(False, True, False, False, False, False, 'mock-owner', 'open', 'orgs', 'opened', 'all')
 
@@ -47,8 +46,8 @@ def test_run_with_gitlab_arg(mock_logger, mock_gitlab, mock_missing_checks):
     mock_logger.info.assert_called()
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', '123')
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', '123')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_discord_webhook_url(mock_logger):
     message = 'No DISCORD_WEBHOOK_URL set. Please correct and try again.'
     with pytest.raises(ValueError):
@@ -57,7 +56,7 @@ def test_run_missing_checks_no_discord_webhook_url(mock_logger):
     mock_logger.critical.assert_called_once_with(message)
 
 
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_github_token(mock_logger):
     message = 'No GITHUB_TOKEN set. Please correct and try again.'
     with pytest.raises(ValueError):
@@ -66,7 +65,7 @@ def test_run_missing_checks_no_github_token(mock_logger):
     mock_logger.critical.assert_called_once_with(message)
 
 
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_gitlab_api_key(mock_logger):
     message = 'No GITLAB_API_KEY set. Please correct and try again.'
     with pytest.raises(ValueError):
@@ -75,8 +74,8 @@ def test_run_missing_checks_no_gitlab_api_key(mock_logger):
     mock_logger.critical.assert_called_once_with(message)
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', '123')
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', '123')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_slack_bot_token(mock_logger):
     message = 'No SLACK_BOT_TOKEN set. Please correct and try again.'
     with pytest.raises(ValueError):
@@ -85,9 +84,9 @@ def test_run_missing_checks_no_slack_bot_token(mock_logger):
     mock_logger.critical.assert_called_once_with(message)
 
 
-@mock.patch('pullbug.cli.SLACK_BOT_TOKEN', '123')
-@mock.patch('pullbug.cli.GITHUB_TOKEN', '123')
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.SLACK_BOT_TOKEN', '123')
+@patch('pullbug.cli.GITHUB_TOKEN', '123')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_slack_channel(mock_logger):
     message = 'No SLACK_CHANNEL set. Please correct and try again.'
     with pytest.raises(ValueError):
@@ -96,8 +95,8 @@ def test_run_missing_checks_no_slack_channel(mock_logger):
     mock_logger.critical.assert_called_once_with(message)
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', '123')
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', '123')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_rocket_chat_url(mock_logger):
     message = 'No ROCKET_CHAT_URL set. Please correct and try again.'
     with pytest.raises(ValueError):
@@ -106,11 +105,11 @@ def test_run_missing_checks_no_rocket_chat_url(mock_logger):
     mock_logger.critical.assert_called_once_with(message)
 
 
-@mock.patch('pullbug.cli.ROCKET_CHAT_URL', 'http://mock-url.com')
-@mock.patch('pullbug.cli.SLACK_CHANNEL', 'mock-channel')
-@mock.patch('pullbug.cli.SLACK_BOT_TOKEN', '123')
-@mock.patch('pullbug.cli.GITHUB_TOKEN', '123')
-@mock.patch('pullbug.cli.LOGGER')
+@patch('pullbug.cli.ROCKET_CHAT_URL', 'http://mock-url.com')
+@patch('pullbug.cli.SLACK_CHANNEL', 'mock-channel')
+@patch('pullbug.cli.SLACK_BOT_TOKEN', '123')
+@patch('pullbug.cli.GITHUB_TOKEN', '123')
+@patch('pullbug.cli.LOGGER')
 def test_run_missing_checks_no_errors(mock_logger):
     PullBug.run_missing_checks(True, False, False, False, True)
 

--- a/test/unit/test_github_bug.py
+++ b/test/unit/test_github_bug.py
@@ -1,6 +1,6 @@
 from test.conftest import MockResponse
+from unittest.mock import patch
 
-import mock
 import pytest
 import requests
 from pullbug.github_bug import GithubBug
@@ -8,10 +8,10 @@ from pullbug.github_bug import GithubBug
 GITHUB_TOKEN = '123'
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.github_bug.GithubBug.get_pull_requests')
-@mock.patch('pullbug.github_bug.GithubBug.get_repos')
-@mock.patch('pullbug.github_bug.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.github_bug.GithubBug.get_pull_requests')
+@patch('pullbug.github_bug.GithubBug.get_repos')
+@patch('pullbug.github_bug.LOGGER')
 def test_run_success(mock_logger, mock_get_repos, mock_pull_request):
     GithubBug.run('mock-owner', 'open', 'orgs', False, False, False, False)
 
@@ -20,11 +20,11 @@ def test_run_success(mock_logger, mock_get_repos, mock_pull_request):
     mock_logger.info.assert_called()
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.github_bug.GithubBug.iterate_pull_requests')
-@mock.patch('pullbug.github_bug.GithubBug.get_pull_requests', return_value=[])
-@mock.patch('pullbug.github_bug.GithubBug.get_repos')
-@mock.patch('pullbug.github_bug.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.github_bug.GithubBug.iterate_pull_requests')
+@patch('pullbug.github_bug.GithubBug.get_pull_requests', return_value=[])
+@patch('pullbug.github_bug.GithubBug.get_repos')
+@patch('pullbug.github_bug.LOGGER')
 def test_run_no_pull_requests(mock_logger, mock_get_repos, mock_pull_request, mock_iterate_pull_requests):
     GithubBug.run('mock-owner', 'open', 'orgs', False, False, False, False)
 
@@ -33,11 +33,11 @@ def test_run_no_pull_requests(mock_logger, mock_get_repos, mock_pull_request, mo
     mock_logger.info.assert_called()
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.messages.Messages.send_discord_message')
-@mock.patch('pullbug.github_bug.GithubBug.get_pull_requests')
-@mock.patch('pullbug.github_bug.GithubBug.get_repos')
-@mock.patch('pullbug.github_bug.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.messages.Messages.send_discord_message')
+@patch('pullbug.github_bug.GithubBug.get_pull_requests')
+@patch('pullbug.github_bug.GithubBug.get_repos')
+@patch('pullbug.github_bug.LOGGER')
 def test_run_with_discord(mock_logger, mock_get_repos, mock_pull_request, mock_discord):
     GithubBug.run('mock-owner', 'open', 'orgs', False, True, False, False)
 
@@ -47,11 +47,11 @@ def test_run_with_discord(mock_logger, mock_get_repos, mock_pull_request, mock_d
     mock_logger.info.assert_called()
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.messages.Messages.send_slack_message')
-@mock.patch('pullbug.github_bug.GithubBug.get_pull_requests')
-@mock.patch('pullbug.github_bug.GithubBug.get_repos')
-@mock.patch('pullbug.github_bug.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.messages.Messages.send_slack_message')
+@patch('pullbug.github_bug.GithubBug.get_pull_requests')
+@patch('pullbug.github_bug.GithubBug.get_repos')
+@patch('pullbug.github_bug.LOGGER')
 def test_run_with_slack(mock_logger, mock_get_repos, mock_pull_request, mock_slack):
     GithubBug.run('mock-owner', 'open', 'orgs', False, False, True, False)
 
@@ -61,11 +61,11 @@ def test_run_with_slack(mock_logger, mock_get_repos, mock_pull_request, mock_sla
     mock_logger.info.assert_called()
 
 
-@mock.patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.messages.Messages.send_rocketchat_message')
-@mock.patch('pullbug.github_bug.GithubBug.get_pull_requests')
-@mock.patch('pullbug.github_bug.GithubBug.get_repos')
-@mock.patch('pullbug.github_bug.LOGGER')
+@patch('pullbug.cli.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.messages.Messages.send_rocketchat_message')
+@patch('pullbug.github_bug.GithubBug.get_pull_requests')
+@patch('pullbug.github_bug.GithubBug.get_repos')
+@patch('pullbug.github_bug.LOGGER')
 def test_run_with_rocketchat(mock_logger, mock_get_repos, mock_pull_request, mock_rocketchat):
     GithubBug.run('mock-owner', 'open', 'orgs', False, False, False, True)
 
@@ -75,25 +75,24 @@ def test_run_with_rocketchat(mock_logger, mock_get_repos, mock_pull_request, moc
     mock_logger.info.assert_called()
 
 
-@mock.patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.github_bug.GITHUB_HEADERS')
-@mock.patch('pullbug.github_bug.LOGGER')
-@mock.patch('requests.get')
+@patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.github_bug.GITHUB_HEADERS')
+@patch('pullbug.github_bug.LOGGER')
+@patch('requests.get')
 def test_get_repos_success(mock_request, mock_logger, mock_headers, _mock_user, _mock_github_context):
     # TODO: Mock this request better and assert additional values
     GithubBug.get_repos(_mock_user, _mock_github_context)
 
     mock_request.assert_called_once_with(
-        f'https://api.github.com/{_mock_github_context}/{_mock_user}/repos?per_page=100',
-        headers=mock_headers
+        f'https://api.github.com/{_mock_github_context}/{_mock_user}/repos?per_page=100', headers=mock_headers
     )
     assert mock_logger.info.call_count == 2
 
 
-@mock.patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.github_bug.GITHUB_HEADERS')
-@mock.patch('pullbug.github_bug.LOGGER')
-@mock.patch('requests.get', return_value=MockResponse(text='Not Found'))
+@patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.github_bug.GITHUB_HEADERS')
+@patch('pullbug.github_bug.LOGGER')
+@patch('requests.get', return_value=MockResponse(text='Not Found'))
 def test_get_repos_value_exception(mock_request, mock_logger, mock_headers, _mock_user, _mock_github_context):
     with pytest.raises(ValueError):
         GithubBug.get_repos(_mock_user, _mock_github_context)
@@ -103,21 +102,19 @@ def test_get_repos_value_exception(mock_request, mock_logger, mock_headers, _moc
     )
 
 
-@mock.patch('pullbug.github_bug.LOGGER')
-@mock.patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))
+@patch('pullbug.github_bug.LOGGER')
+@patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_get_repos_requests_exception(mock_request, mock_logger, _mock_user, _mock_github_context):
     with pytest.raises(requests.exceptions.RequestException):
         GithubBug.get_repos(_mock_user, _mock_github_context)
 
-    mock_logger.error.assert_called_once_with(
-        'Could not retrieve GitHub repos: mock-error'
-    )
+    mock_logger.error.assert_called_once_with('Could not retrieve GitHub repos: mock-error')
 
 
-@mock.patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.github_bug.GITHUB_HEADERS')
-@mock.patch('pullbug.github_bug.LOGGER')
-@mock.patch('requests.get')
+@patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.github_bug.GITHUB_HEADERS')
+@patch('pullbug.github_bug.LOGGER')
+@patch('requests.get')
 def test_get_pull_requests_success(mock_request, mock_logger, mock_headers, _mock_repo, _mock_github_state, _mock_user):
     # TODO: Mock this request better and assert additional values
     mock_repos = [_mock_repo]
@@ -125,32 +122,34 @@ def test_get_pull_requests_success(mock_request, mock_logger, mock_headers, _moc
 
     mock_request.assert_called_once_with(
         f'https://api.github.com/repos/{_mock_user}/{_mock_repo["name"]}/pulls?state={_mock_github_state}&per_page=100',
-        headers=mock_headers
+        headers=mock_headers,
     )
     assert mock_logger.info.call_count == 2
     # assert len(result) > 0  # TODO: Assert a mock value actually makes it in
     assert isinstance(result, list)
 
 
-@mock.patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
-@mock.patch('pullbug.github_bug.GITHUB_HEADERS')
-@mock.patch('pullbug.github_bug.LOGGER')
-@mock.patch('requests.get', return_value=None)
-def test_get_pull_requests_success_no_pull_requests(mock_request, mock_logger, mock_headers, _mock_repo, _mock_github_state, _mock_user):  # noqa
+@patch('pullbug.github_bug.GITHUB_TOKEN', GITHUB_TOKEN)
+@patch('pullbug.github_bug.GITHUB_HEADERS')
+@patch('pullbug.github_bug.LOGGER')
+@patch('requests.get', return_value=None)
+def test_get_pull_requests_success_no_pull_requests(
+    mock_request, mock_logger, mock_headers, _mock_repo, _mock_github_state, _mock_user
+):  # noqa
     # TODO: Mock this request better and assert additional values
     mock_repos = [_mock_repo]
     result = GithubBug.get_pull_requests(mock_repos, _mock_user, _mock_github_state)
 
     mock_request.assert_called_once_with(
         f'https://api.github.com/repos/{_mock_user}/{_mock_repo["name"]}/pulls?state={_mock_github_state}&per_page=100',
-        headers=mock_headers
+        headers=mock_headers,
     )
     assert isinstance(result, list)
     assert len(result) == 0
 
 
-@mock.patch('pullbug.github_bug.LOGGER')
-@mock.patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))
+@patch('pullbug.github_bug.LOGGER')
+@patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_get_pull_requests_request_exception(mock_request, mock_logger, _mock_repo, _mock_user, _mock_github_state):
     mock_repos = [_mock_repo]
     with pytest.raises(requests.exceptions.RequestException):
@@ -161,8 +160,8 @@ def test_get_pull_requests_request_exception(mock_request, mock_logger, _mock_re
     )
 
 
-@mock.patch('pullbug.github_bug.LOGGER')
-@mock.patch('requests.get', side_effect=TypeError('mock-error'))
+@patch('pullbug.github_bug.LOGGER')
+@patch('requests.get', side_effect=TypeError('mock-error'))
 def test_get_pull_requests_type_error_exception(mock_request, mock_logger, _mock_repo, _mock_user, _mock_github_state):
     mock_repos = [_mock_repo]
     with pytest.raises(TypeError):
@@ -173,7 +172,7 @@ def test_get_pull_requests_type_error_exception(mock_request, mock_logger, _mock
     )
 
 
-@mock.patch('pullbug.github_bug.Messages.prepare_github_message', return_value=[['mock-message'], ['mock-message']])
+@patch('pullbug.github_bug.Messages.prepare_github_message', return_value=[['mock-message'], ['mock-message']])
 def test_iterate_pull_requests_wip_title(mock_prepare_message, _mock_pull_request):
     _mock_pull_request['title'] = 'wip: mock-pull-request'
     mock_pull_requests = [_mock_pull_request]
@@ -182,7 +181,7 @@ def test_iterate_pull_requests_wip_title(mock_prepare_message, _mock_pull_reques
     mock_prepare_message.assert_called_once()
 
 
-@mock.patch('pullbug.github_bug.Messages.prepare_github_message')
+@patch('pullbug.github_bug.Messages.prepare_github_message')
 def test_iterate_pull_requests_wip_setting_absent(mock_prepare_message, _mock_pull_request):
     _mock_pull_request['title'] = 'wip: mock-pull-request'
     mock_pull_requests = [_mock_pull_request]

--- a/test/unit/test_gitlab_bug.py
+++ b/test/unit/test_gitlab_bug.py
@@ -1,6 +1,6 @@
 from test.conftest import MockResponse
+from unittest.mock import patch
 
-import mock
 import pytest
 import requests
 from pullbug.gitlab_bug import GitlabBug
@@ -9,20 +9,28 @@ GITLAB_API_KEY = '123'
 MOCK_URL = 'http://mock-url.com'
 
 
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
-@mock.patch('pullbug.messages.Messages.send_rocketchat_message')
-@mock.patch('pullbug.messages.Messages.send_slack_message')
-@mock.patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
-@mock.patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
-@mock.patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
-@mock.patch('pullbug.gitlab_bug.GITLAB_HEADERS')
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get')
-def test_run_no_slack_or_rocketchat_messages(mock_request, mock_logger, mock_headers,
-                                             mock_get_merge_requests, mock_iterate_merge_requests,
-                                             mock_prepare_message, mock_slack, mock_rocketchat,
-                                             _mock_gitlab_scope, _mock_gitlab_state):
+@patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
+@patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
+@patch('pullbug.messages.Messages.send_rocketchat_message')
+@patch('pullbug.messages.Messages.send_slack_message')
+@patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
+@patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
+@patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
+@patch('pullbug.gitlab_bug.GITLAB_HEADERS')
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get')
+def test_run_no_slack_or_rocketchat_messages(
+    mock_request,
+    mock_logger,
+    mock_headers,
+    mock_get_merge_requests,
+    mock_iterate_merge_requests,
+    mock_prepare_message,
+    mock_slack,
+    mock_rocketchat,
+    _mock_gitlab_scope,
+    _mock_gitlab_state,
+):
     GitlabBug.run(_mock_gitlab_scope, _mock_gitlab_state, False, False, False, False)
 
     mock_logger.info.assert_called()
@@ -32,20 +40,28 @@ def test_run_no_slack_or_rocketchat_messages(mock_request, mock_logger, mock_hea
     mock_rocketchat.assert_not_called()
 
 
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
-@mock.patch('pullbug.messages.Messages.send_discord_message')
-@mock.patch('pullbug.messages.Messages.send_slack_message')
-@mock.patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
-@mock.patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
-@mock.patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
-@mock.patch('pullbug.gitlab_bug.GITLAB_HEADERS')
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get')
-def test_run_discord_message(mock_request, mock_logger, mock_headers,
-                             mock_get_merge_requests, mock_iterate_merge_requests,
-                             mock_prepare_message, mock_slack, mock_discord,
-                             _mock_gitlab_scope, _mock_gitlab_state):
+@patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
+@patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
+@patch('pullbug.messages.Messages.send_discord_message')
+@patch('pullbug.messages.Messages.send_slack_message')
+@patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
+@patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
+@patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
+@patch('pullbug.gitlab_bug.GITLAB_HEADERS')
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get')
+def test_run_discord_message(
+    mock_request,
+    mock_logger,
+    mock_headers,
+    mock_get_merge_requests,
+    mock_iterate_merge_requests,
+    mock_prepare_message,
+    mock_slack,
+    mock_discord,
+    _mock_gitlab_scope,
+    _mock_gitlab_state,
+):
     GitlabBug.run(_mock_gitlab_scope, _mock_gitlab_state, False, True, False, False)
 
     mock_logger.info.assert_called()
@@ -54,20 +70,28 @@ def test_run_discord_message(mock_request, mock_logger, mock_headers,
     mock_discord.assert_called_once()
 
 
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
-@mock.patch('pullbug.messages.Messages.send_rocketchat_message')
-@mock.patch('pullbug.messages.Messages.send_slack_message')
-@mock.patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
-@mock.patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
-@mock.patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
-@mock.patch('pullbug.gitlab_bug.GITLAB_HEADERS')
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get')
-def test_run_slack_message(mock_request, mock_logger, mock_headers,
-                           mock_get_merge_requests, mock_iterate_merge_requests,
-                           mock_prepare_message, mock_slack, mock_rocketchat,
-                           _mock_gitlab_scope, _mock_gitlab_state):
+@patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
+@patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
+@patch('pullbug.messages.Messages.send_rocketchat_message')
+@patch('pullbug.messages.Messages.send_slack_message')
+@patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
+@patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
+@patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
+@patch('pullbug.gitlab_bug.GITLAB_HEADERS')
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get')
+def test_run_slack_message(
+    mock_request,
+    mock_logger,
+    mock_headers,
+    mock_get_merge_requests,
+    mock_iterate_merge_requests,
+    mock_prepare_message,
+    mock_slack,
+    mock_rocketchat,
+    _mock_gitlab_scope,
+    _mock_gitlab_state,
+):
     GitlabBug.run(_mock_gitlab_scope, _mock_gitlab_state, False, False, True, False)
 
     mock_logger.info.assert_called()
@@ -76,20 +100,28 @@ def test_run_slack_message(mock_request, mock_logger, mock_headers,
     mock_slack.assert_called_once()
 
 
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
-@mock.patch('pullbug.messages.Messages.send_rocketchat_message')
-@mock.patch('pullbug.messages.Messages.send_slack_message')
-@mock.patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
-@mock.patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
-@mock.patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
-@mock.patch('pullbug.gitlab_bug.GITLAB_HEADERS')
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get')
-def test_run_rocketchat_message(mock_request, mock_logger, mock_headers,
-                                mock_get_merge_requests, mock_iterate_merge_requests,
-                                mock_prepare_message, mock_slack, mock_rocketchat,
-                                _mock_gitlab_scope, _mock_gitlab_state):
+@patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
+@patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
+@patch('pullbug.messages.Messages.send_rocketchat_message')
+@patch('pullbug.messages.Messages.send_slack_message')
+@patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
+@patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
+@patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests')
+@patch('pullbug.gitlab_bug.GITLAB_HEADERS')
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get')
+def test_run_rocketchat_message(
+    mock_request,
+    mock_logger,
+    mock_headers,
+    mock_get_merge_requests,
+    mock_iterate_merge_requests,
+    mock_prepare_message,
+    mock_slack,
+    mock_rocketchat,
+    _mock_gitlab_scope,
+    _mock_gitlab_state,
+):
     GitlabBug.run(_mock_gitlab_scope, _mock_gitlab_state, False, False, False, True)
 
     mock_logger.info.assert_called()
@@ -98,20 +130,28 @@ def test_run_rocketchat_message(mock_request, mock_logger, mock_headers,
     mock_slack.assert_not_called()
 
 
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
-@mock.patch('pullbug.messages.Messages.send_rocketchat_message')
-@mock.patch('pullbug.messages.Messages.send_slack_message')
-@mock.patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
-@mock.patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
-@mock.patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests', return_value=[])
-@mock.patch('pullbug.gitlab_bug.GITLAB_HEADERS')
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get')
-def test_run_no_returned_merge_requests(mock_request, mock_logger, mock_headers,
-                                        mock_get_merge_requests, mock_iterate_merge_requests,
-                                        mock_prepare_message, mock_slack, mock_rocketchat,
-                                        _mock_gitlab_scope, _mock_gitlab_state):
+@patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
+@patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
+@patch('pullbug.messages.Messages.send_rocketchat_message')
+@patch('pullbug.messages.Messages.send_slack_message')
+@patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
+@patch('pullbug.gitlab_bug.GitlabBug.iterate_merge_requests', return_value=[['mock-message'], ['mock-message']])
+@patch('pullbug.gitlab_bug.GitlabBug.get_merge_requests', return_value=[])
+@patch('pullbug.gitlab_bug.GITLAB_HEADERS')
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get')
+def test_run_no_returned_merge_requests(
+    mock_request,
+    mock_logger,
+    mock_headers,
+    mock_get_merge_requests,
+    mock_iterate_merge_requests,
+    mock_prepare_message,
+    mock_slack,
+    mock_rocketchat,
+    _mock_gitlab_scope,
+    _mock_gitlab_state,
+):
     GitlabBug.run(_mock_gitlab_scope, _mock_gitlab_state, False, False, False, False)
 
     mock_logger.info.assert_called_with('No merge requests are available from GitLab.')
@@ -120,30 +160,32 @@ def test_run_no_returned_merge_requests(mock_request, mock_logger, mock_headers,
     mock_rocketchat.assert_not_called()
 
 
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
-@mock.patch('pullbug.gitlab_bug.GITLAB_HEADERS')
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get')
-def test_get_merge_requests_success(mock_request, mock_logger, mock_headers, _mock_gitlab_scope,
-                                    _mock_gitlab_state, _mock_url):
+@patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
+@patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
+@patch('pullbug.gitlab_bug.GITLAB_HEADERS')
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get')
+def test_get_merge_requests_success(
+    mock_request, mock_logger, mock_headers, _mock_gitlab_scope, _mock_gitlab_state, _mock_url
+):
     # TODO: Mock this request better and assert additional values
     GitlabBug.get_merge_requests(_mock_gitlab_scope, _mock_gitlab_state)
 
     mock_request.assert_called_once_with(
         f'{_mock_url}/merge_requests?scope={_mock_gitlab_scope}&state={_mock_gitlab_state}&per_page=100',
-        headers=mock_headers
+        headers=mock_headers,
     )
     assert mock_logger.info.call_count == 2
 
 
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
-@mock.patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
-@mock.patch('pullbug.gitlab_bug.GITLAB_HEADERS')
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get', return_value=MockResponse(text='does not have a valid value'))
-def test_get_merge_value_exception(mock_request, mock_logger, mock_headers, _mock_gitlab_scope,
-                                   _mock_gitlab_state, _mock_url):
+@patch('pullbug.gitlab_bug.GITLAB_API_KEY', GITLAB_API_KEY)
+@patch('pullbug.gitlab_bug.GITLAB_API_URL', MOCK_URL)
+@patch('pullbug.gitlab_bug.GITLAB_HEADERS')
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get', return_value=MockResponse(text='does not have a valid value'))
+def test_get_merge_value_exception(
+    mock_request, mock_logger, mock_headers, _mock_gitlab_scope, _mock_gitlab_state, _mock_url
+):
     with pytest.raises(ValueError):
         GitlabBug.get_merge_requests(_mock_gitlab_scope, _mock_gitlab_state)
 
@@ -152,18 +194,16 @@ def test_get_merge_value_exception(mock_request, mock_logger, mock_headers, _moc
     )
 
 
-@mock.patch('pullbug.gitlab_bug.LOGGER')
-@mock.patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))
+@patch('pullbug.gitlab_bug.LOGGER')
+@patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_get_repos_exception(mock_request, mock_logger, _mock_gitlab_scope, _mock_gitlab_state):
     with pytest.raises(requests.exceptions.RequestException):
         GitlabBug.get_merge_requests(_mock_gitlab_scope, _mock_gitlab_state)
 
-    mock_logger.error.assert_called_once_with(
-        'Could not retrieve GitLab merge requests: mock-error'
-    )
+    mock_logger.error.assert_called_once_with('Could not retrieve GitLab merge requests: mock-error')
 
 
-@mock.patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message', return_value=[['mock-message'], ['mock-message']])
+@patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message', return_value=[['mock-message'], ['mock-message']])
 def test_iterate_merge_requests_wip_title(mock_prepare_message, _mock_merge_request):
     _mock_merge_request['title'] = 'wip: mock-merge-request'
     mock_merge_requests = [_mock_merge_request]
@@ -172,7 +212,7 @@ def test_iterate_merge_requests_wip_title(mock_prepare_message, _mock_merge_requ
     mock_prepare_message.assert_called_once()
 
 
-@mock.patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
+@patch('pullbug.gitlab_bug.Messages.prepare_gitlab_message')
 def test_iterate_merge_requests_wip_setting_absent(mock_prepare_message, _mock_merge_request):
     _mock_merge_request['title'] = 'wip: mock-merge-request'
     mock_merge_requests = [_mock_merge_request]

--- a/test/unit/test_logger.py
+++ b/test/unit/test_logger.py
@@ -1,13 +1,14 @@
-import mock
+from unittest.mock import mock_open, patch
+
 from pullbug import PullBugLogger
 
 
-@mock.patch('pullbug.logger.LOG_PATH', 'test/mock-dir')
-@mock.patch('pullbug.logger.LOG_FILE', './test/test.log')
-@mock.patch('os.makedirs')
-@mock.patch('pullbug.github_bug.LOGGER')
+@patch('pullbug.logger.LOG_PATH', 'test/mock-dir')
+@patch('pullbug.logger.LOG_FILE', './test/test.log')
+@patch('os.makedirs')
+@patch('pullbug.github_bug.LOGGER')
 def test_setup_logging(mock_logger, mock_make_dirs):
-    with mock.patch('builtins.open', mock.mock_open()):
+    with patch('builtins.open', mock_open()):
         PullBugLogger._setup_logging(mock_logger)
 
     mock_make_dirs.assert_called_once()
@@ -15,10 +16,10 @@ def test_setup_logging(mock_logger, mock_make_dirs):
     mock_logger.addHandler.assert_called()
 
 
-@mock.patch('os.makedirs')
-@mock.patch('pullbug.github_bug.LOGGER')
+@patch('os.makedirs')
+@patch('pullbug.github_bug.LOGGER')
 def test_setup_logging_dir_exists(mock_logger, mock_make_dirs):
-    with mock.patch('builtins.open', mock.mock_open()):
+    with patch('builtins.open', mock_open()):
         PullBugLogger._setup_logging(mock_logger)
 
     mock_make_dirs.assert_not_called()

--- a/test/unit/test_messages.py
+++ b/test/unit/test_messages.py
@@ -1,13 +1,14 @@
-import mock
+from unittest.mock import patch
+
 import pytest
 import requests
 import slack
 from pullbug.messages import Messages
 
 
-@mock.patch('pullbug.messages.DISCORD_WEBHOOK_URL', 'https://discord.com/api/webhooks/channel_id/webhook_id')
-@mock.patch('pullbug.messages.LOGGER')
-@mock.patch('requests.post')
+@patch('pullbug.messages.DISCORD_WEBHOOK_URL', 'https://discord.com/api/webhooks/channel_id/webhook_id')
+@patch('pullbug.messages.LOGGER')
+@patch('requests.post')
 def test_discord_success(mock_request, mock_logger):
     message = 'mock message'
     Messages.send_discord_message([message])
@@ -18,47 +19,41 @@ def test_discord_success(mock_request, mock_logger):
     mock_logger.info.assert_called_once_with('Discord message sent!')
 
 
-@mock.patch('pullbug.messages.LOGGER')
-@mock.patch('requests.post', side_effect=requests.exceptions.RequestException('mock-error'))
+@patch('pullbug.messages.LOGGER')
+@patch('requests.post', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_discord_exception(mock_request, mock_logger):
     message = 'mock message'
     with pytest.raises(requests.exceptions.RequestException):
         Messages.send_discord_message(message)
 
-    mock_logger.error.assert_called_once_with(
-        'Could not send Discord message: mock-error'
-    )
+    mock_logger.error.assert_called_once_with('Could not send Discord message: mock-error')
 
 
-@mock.patch('pullbug.messages.ROCKET_CHAT_URL', 'http://mock-url.com')
-@mock.patch('pullbug.messages.LOGGER')
-@mock.patch('requests.post')
+@patch('pullbug.messages.ROCKET_CHAT_URL', 'http://mock-url.com')
+@patch('pullbug.messages.LOGGER')
+@patch('requests.post')
 def test_rocket_chat_success(mock_request, mock_logger):
     message = 'mock message'
     Messages.send_rocketchat_message(message)
 
-    mock_request.assert_called_once_with(
-        'http://mock-url.com', json={'text': message}
-    )
+    mock_request.assert_called_once_with('http://mock-url.com', json={'text': message})
     mock_logger.info.assert_called_once_with('Rocket Chat message sent!')
 
 
-@mock.patch('pullbug.messages.LOGGER')
-@mock.patch('requests.post', side_effect=requests.exceptions.RequestException('mock-error'))
+@patch('pullbug.messages.LOGGER')
+@patch('requests.post', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_rocket_chat_exception(mock_request, mock_logger):
     message = 'mock message'
     with pytest.raises(requests.exceptions.RequestException):
         Messages.send_rocketchat_message(message)
 
-    mock_logger.error.assert_called_once_with(
-        'Could not send Rocket Chat message: mock-error'
-    )
+    mock_logger.error.assert_called_once_with('Could not send Rocket Chat message: mock-error')
 
 
-@mock.patch('pullbug.messages.SLACK_CHANNEL', 'mock-channel')
-@mock.patch('pullbug.messages.SLACK_BOT_TOKEN', '123')
-@mock.patch('pullbug.messages.LOGGER')
-@mock.patch('slack.WebClient.chat_postMessage')
+@patch('pullbug.messages.SLACK_CHANNEL', 'mock-channel')
+@patch('pullbug.messages.SLACK_BOT_TOKEN', '123')
+@patch('pullbug.messages.LOGGER')
+@patch('slack.WebClient.chat_postMessage')
 def test_slack_success(mock_slack, mock_logger):
     message = 'mock message'
     Messages.send_slack_message(message)
@@ -67,12 +62,13 @@ def test_slack_success(mock_slack, mock_logger):
     mock_logger.info.assert_called_once_with('Slack message sent!')
 
 
-@mock.patch('pullbug.messages.LOGGER')
-@mock.patch('slack.WebClient.chat_postMessage',
-            side_effect=slack.errors.SlackApiError(
-                message='The request to the Slack API failed.',
-                response={'ok': False, 'error': 'not_authed'}
-            ))
+@patch('pullbug.messages.LOGGER')
+@patch(
+    'slack.WebClient.chat_postMessage',
+    side_effect=slack.errors.SlackApiError(
+        message='The request to the Slack API failed.', response={'ok': False, 'error': 'not_authed'}
+    ),
+)
 def test_slack_exception(mock_slack, mock_logger):
     message = 'mock message'
     with pytest.raises(slack.errors.SlackApiError):
@@ -102,7 +98,9 @@ def test_prepare_gitlab_message(_mock_merge_request, _mock_url, _mock_user, _moc
     result, discord_result = Messages.prepare_gitlab_message(_mock_merge_request, False, False, False)
 
     assert 'Merge Request' in result
-    assert f'{_mock_merge_request["assignees"][0]["web_url"]}|{_mock_merge_request["assignees"][0]["username"]}' in result  # noqa
+    assert (
+        f'{_mock_merge_request["assignees"][0]["web_url"]}|{_mock_merge_request["assignees"][0]["username"]}' in result
+    )
     assert f'{_mock_merge_request["web_url"]}|{_mock_merge_request["title"]}' in result
 
 


### PR DESCRIPTION
* Drops support for Python 3.6
* Swaps `mock` library for builtin `unittest.mock` library
* Formats entire project with `Black`