### PR TITLE
feat!: move all env variables to CLI args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+* Replaces all env variables with CLI args for a more uniform experience, various shortcodes for flags were changed or removed as a part of this process (closes #24)
+* Replace all `classmethods` with instance or static methods
+
 ## v2.4.0 (2021-09-20)
 
 * Drops support for Python 3.6

--- a/README.md
+++ b/README.md
@@ -40,35 +40,40 @@ Pullbug is highly customizable allowing you to mix and match version control sof
 
 ```
 Usage:
-    GITHUB_TOKEN=123... SLACK_BOT_TOKEN=123... SLACK_CHANNEL=my-channel pullbug --github --github_owner my_org --slack
+    pullbug --github_token 123... --github --github_owner justintime50
 
 Options:
     -h, --help            show this help message and exit
     -gh, --github         Get bugged about pull requests from GitHub.
-    -gl, --gitlab         Get bugged about merge requests from GitLab.
-    -d, --discord         Send Pullbug messages to Discord.
-    -s, --slack           Send Pullbug messages to Slack.
-    -rc, --rocketchat     Send Pullbug messages to Rocket.Chat.
-    -w, --wip             Include "Work in Progress" pull or merge requests.
-    -gho GITHUB_OWNER, --github_owner GITHUB_OWNER
+    --github_token GITHUB_TOKEN
+                            The token to authenticate with GitHub.
+    -go GITHUB_OWNER, --github_owner GITHUB_OWNER
                             The GitHub owner to retrieve pull requests from (can be a user or organization).
-    -ghs {open,closed,all}, --github_state {open,closed,all}
+    --github_state {open,closed,all}
                             The GitHub state to retrieve pull requests with.
-    -ghc {orgs,users}, --github_context {orgs,users}
+    -gc {orgs,users}, --github_context {orgs,users}
                             The GitHub context to retrieve pull requests with.
-    -glst {opened,closed,locked,merged}, --gitlab_state {opened,closed,locked,merged}
+    -gl, --gitlab         Get bugged about merge requests from GitLab.
+    --gitlab_token GITLAB_TOKEN
+                            The API key to authenticate with GitLab.
+    -gu GITLAB_URL, --gitlab_url GITLAB_URL
+                            The URL of the GitLab instance to use.
+    --gitlab_state {opened,closed,locked,merged}
                             The GitLab state to retrieve merge requests with.
-    -glsc {all,created_by_me,assigned_to_me}, --gitlab_scope {all,created_by_me,assigned_to_me}
+    --gitlab_scope {all,created_by_me,assigned_to_me}
                             The GitLab state to retrieve pull requests with.
-
-Environment Variables:
-    GITHUB_TOKEN        The GitHub Token used to authenticate with the GitHub API.
-    GITLAB_API_KEY      The GitLab API Key used to authenticate with the GitLab API.
-    GITLAB_API_URL      The GitLab API url for your GitLab instance. Default: https://gitlab.com/api/v4.
-    DISCORD_WEBHOOK_URL The Discord webhook url to send a message to. Will look like: https://discord.com/api/webhooks/channel_id/webhook_id
-    SLACK_BOT_TOKEN     The Slackbot Token used to authenticate with Slack.
-    SLACK_CHANNEL       The Slack channel to post a message to.
-    ROCKET_CHAT_URL     The Rocket.Chat url of the room to post a message to.
+    -d, --discord         Send Pullbug messages to Discord.
+    -du DISCORD_URL, --discord_url DISCORD_URL
+                            The Discord webhook URL to send messages to.
+    -s, --slack           Send Pullbug messages to Slack.
+    -st SLACK_TOKEN, --slack_token SLACK_TOKEN
+                            The Slackbot token to authenticate with Slack.
+    -sc SLACK_CHANNEL, --slack_channel SLACK_CHANNEL
+                            The Slack channel to send messages to.
+    -rc, --rocketchat     Send Pullbug messages to Rocket.Chat.
+    -ru ROCKETCHAT_URL, --rocketchat_url ROCKETCHAT_URL
+                            The Rocket.Chat URL to send messages to.
+    -w, --wip             Include "Work in Progress" pull or merge requests.
 ```
 
 ## Development

--- a/pullbug/cli.py
+++ b/pullbug/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 
 from pullbug.github_bug import GithubBug
 from pullbug.gitlab_bug import GitlabBug
@@ -158,6 +159,14 @@ class PullBugCLI:
             default=False,
             help='Include "Work in Progress" pull or merge requests.',
         )
+        parser.add_argument(
+            '-l',
+            '--location',
+            required=False,
+            type=str,
+            default=os.path.expanduser('~/pullbug'),
+            help='The location of the Pullbug logs and files.',
+        )
         parser.parse_args(namespace=self)
 
     def run(self):
@@ -181,6 +190,7 @@ class PullBugCLI:
             rocketchat=self.rocketchat,
             rocketchat_url=self.rocketchat_url,
             wip=self.wip,
+            location=self.location,
         )
 
 
@@ -205,6 +215,7 @@ class PullBug:
         rocketchat,
         rocketchat_url,
         wip,
+        location,
     ):
         """Run Pullbug based on the configuration."""
         PullBugLogger._setup_logging(LOGGER)

--- a/pullbug/cli.py
+++ b/pullbug/cli.py
@@ -1,28 +1,19 @@
 import argparse
 import logging
-import os
-
-from dotenv import load_dotenv
 
 from pullbug.github_bug import GithubBug
 from pullbug.gitlab_bug import GitlabBug
 from pullbug.logger import PullBugLogger
 
-GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
-GITLAB_API_KEY = os.getenv('GITLAB_API_KEY')
-GITLAB_API_URL = os.getenv('GITLAB_API_URL', 'https://gitlab.com/api/v4')
-DISCORD_WEBHOOK_URL = os.getenv('DISCORD_WEBHOOK_URL')
-SLACK_BOT_TOKEN = os.getenv('SLACK_BOT_TOKEN')
-SLACK_CHANNEL = os.getenv('SLACK_CHANNEL')
-ROCKET_CHAT_URL = os.getenv('ROCKET_CHAT_URL')
 LOGGER = logging.getLogger(__name__)
 
 
 class PullBugCLI:
     def __init__(self):
-        """Initiate CLI args."""
         parser = argparse.ArgumentParser(
-            description='Get bugged via Slack or RocketChat to merge your GitHub pull requests or GitLab merge requests.'  # noqa
+            description=(
+                'Get bugged via Slack or RocketChat to merge your GitHub pull requests or GitLab merge requests.'
+            )
         )
         parser.add_argument(
             '-gh',
@@ -33,12 +24,75 @@ class PullBugCLI:
             help='Get bugged about pull requests from GitHub.',
         )
         parser.add_argument(
+            '--github_token',
+            required=False,
+            type=str,
+            default=None,
+            help='The token to authenticate with GitHub.',
+        )
+        parser.add_argument(
+            '-go',
+            '--github_owner',
+            required=False,
+            type=str,
+            default=None,
+            help='The GitHub owner to retrieve pull requests from (can be a user or organization).',
+        )
+        parser.add_argument(
+            '--github_state',
+            required=False,
+            type=str,
+            default='open',
+            choices=['open', 'closed', 'all'],
+            help='The GitHub state to retrieve pull requests with.',
+        )
+        parser.add_argument(
+            '-gc',
+            '--github_context',
+            required=False,
+            type=str,
+            default='orgs',
+            choices=['orgs', 'users'],
+            help='The GitHub context to retrieve pull requests with.',
+        )
+        parser.add_argument(
             '-gl',
             '--gitlab',
             required=False,
             action='store_true',
             default=False,
             help='Get bugged about merge requests from GitLab.',
+        )
+        parser.add_argument(
+            '--gitlab_token',
+            required=False,
+            type=str,
+            default=None,
+            help='The API key to authenticate with GitLab.',
+        )
+        parser.add_argument(
+            '-gu',
+            '--gitlab_url',
+            required=False,
+            type=str,
+            default='https://gitlab.com/api/v4',
+            help='The URL of the GitLab instance to use.',
+        )
+        parser.add_argument(
+            '--gitlab_state',
+            required=False,
+            type=str,
+            default='opened',
+            choices=['opened', 'closed', 'locked', 'merged'],
+            help='The GitLab state to retrieve merge requests with.',
+        )
+        parser.add_argument(
+            '--gitlab_scope',
+            required=False,
+            type=str,
+            default='all',
+            choices=['all', 'created_by_me', 'assigned_to_me'],
+            help='The GitLab state to retrieve pull requests with.',
         )
         parser.add_argument(
             '-d',
@@ -49,12 +103,36 @@ class PullBugCLI:
             help='Send Pullbug messages to Discord.',
         )
         parser.add_argument(
+            '-du',
+            '--discord_url',
+            required=False,
+            type=str,
+            default=None,
+            help='The Discord webhook URL to send messages to.',
+        )
+        parser.add_argument(
             '-s',
             '--slack',
             required=False,
             action='store_true',
             default=False,
             help='Send Pullbug messages to Slack.',
+        )
+        parser.add_argument(
+            '-st',
+            '--slack_token',
+            required=False,
+            type=str,
+            default=None,
+            help='The Slackbot token to authenticate with Slack.',
+        )
+        parser.add_argument(
+            '-sc',
+            '--slack_channel',
+            required=False,
+            type=str,
+            default=None,
+            help='The Slack channel to send messages to.',
         )
         parser.add_argument(
             '-rc',
@@ -65,6 +143,14 @@ class PullBugCLI:
             help='Send Pullbug messages to Rocket.Chat.',
         )
         parser.add_argument(
+            '-ru',
+            '--rocketchat_url',
+            required=False,
+            type=str,
+            default=False,
+            help='The Rocket.Chat URL to send messages to.',
+        )
+        parser.add_argument(
             '-w',
             '--wip',
             required=False,
@@ -72,123 +158,105 @@ class PullBugCLI:
             default=False,
             help='Include "Work in Progress" pull or merge requests.',
         )
-        parser.add_argument(
-            '-gho',
-            '--github_owner',
-            required=False,
-            type=str,
-            default=None,
-            help='The GitHub owner to retrieve pull requests from (can be a user or organization).',
-        )
-        parser.add_argument(
-            '-ghs',
-            '--github_state',
-            required=False,
-            type=str,
-            default='open',
-            choices=['open', 'closed', 'all'],
-            help='The GitHub state to retrieve pull requests with.',
-        )
-        parser.add_argument(
-            '-ghc',
-            '--github_context',
-            required=False,
-            type=str,
-            default='orgs',
-            choices=['orgs', 'users'],
-            help='The GitHub context to retrieve pull requests with.',
-        )
-        parser.add_argument(
-            '-glst',
-            '--gitlab_state',
-            required=False,
-            type=str,
-            default='opened',
-            choices=['opened', 'closed', 'locked', 'merged'],
-            help='The GitLab state to retrieve merge requests with.',
-        )
-        parser.add_argument(
-            '-glsc',
-            '--gitlab_scope',
-            required=False,
-            type=str,
-            default='all',
-            choices=['all', 'created_by_me', 'assigned_to_me'],
-            help='The GitLab state to retrieve pull requests with.',
-        )
         parser.parse_args(namespace=self)
 
     def run(self):
         """Send command line args to the main run function."""
         PullBug.run(
             github=self.github,
-            gitlab=self.gitlab,
-            discord=self.discord,
-            slack=self.slack,
-            rocketchat=self.rocketchat,
-            wip=self.wip,
+            github_token=self.github_token,
             github_owner=self.github_owner,
             github_state=self.github_state,
             github_context=self.github_context,
+            gitlab=self.gitlab,
+            gitlab_token=self.gitlab_token,
+            gitlab_url=self.gitlab_url,
             gitlab_state=self.gitlab_state,
             gitlab_scope=self.gitlab_scope,
+            discord=self.discord,
+            discord_url=self.discord_url,
+            slack=self.slack,
+            slack_token=self.slack_token,
+            slack_channel=self.slack_channel,
+            rocketchat=self.rocketchat,
+            rocketchat_url=self.rocketchat_url,
+            wip=self.wip,
         )
 
 
 class PullBug:
-    @classmethod
     def run(
-        cls,
+        self,
         github,
-        gitlab,
-        discord,
-        slack,
-        rocketchat,
-        wip,
+        github_token,
         github_owner,
         github_state,
         github_context,
+        gitlab,
+        gitlab_token,
+        gitlab_url,
         gitlab_state,
         gitlab_scope,
+        discord,
+        discord_url,
+        slack,
+        slack_token,
+        slack_channel,
+        rocketchat,
+        rocketchat_url,
+        wip,
     ):
         """Run Pullbug based on the configuration."""
         PullBugLogger._setup_logging(LOGGER)
         LOGGER.info('Running Pullbug...')
-        load_dotenv()
-        cls.run_missing_checks(github, gitlab, discord, slack, rocketchat)
-        if github:
-            GithubBug.run(github_owner, github_state, github_context, wip, discord, slack, rocketchat)
+        self.run_missing_checks()
+        if self.github:
+            github_bug = GithubBug(
+                self.github_token,
+                self.github_owner,
+                self.github_state,
+                self.github_context,
+                self.wip,
+                self.discord,
+                self.discord_url,
+                self.slack,
+                self.slack_token,
+                self.slack_channel,
+                self.rocketchat,
+                self.rocketchat_url,
+            )
+
+            github_bug.run()
         if gitlab:
-            GitlabBug.run(gitlab_scope, gitlab_state, wip, discord, slack, rocketchat)
+            gitlab_bug = GitlabBug(
+                self.gitlab_scope, self.gitlab_state, self.wip, self.discord, self.slack, self.rocketchat
+            )
+
+            gitlab_bug.run()
         LOGGER.info('Pullbug finished bugging!')
 
-    @classmethod
-    def run_missing_checks(cls, github, gitlab, discord, slack, rocketchat):
-        """Check that values are set based on
-        configuration before proceeding.
-        """
-        if not github and not gitlab:
+    def run_missing_checks(self):
+        """Check that values are set based on configuration before proceeding."""
+        if not self.github and not self.gitlab:
             message = 'Neither "github" nor "gitlab" flags were passed, one is required. Please correct and try again.'
             LOGGER.critical(message)
             raise ValueError(message)
-        if github and not GITHUB_TOKEN:
-            cls.throw_missing_error('GITHUB_TOKEN')
-        if gitlab and not GITLAB_API_KEY:
-            cls.throw_missing_error('GITLAB_API_KEY')
-        if discord and not DISCORD_WEBHOOK_URL:
-            cls.throw_missing_error('DISCORD_WEBHOOK_URL')
-        if slack and not SLACK_BOT_TOKEN:
-            cls.throw_missing_error('SLACK_BOT_TOKEN')
-        if slack and not SLACK_CHANNEL:
-            cls.throw_missing_error('SLACK_CHANNEL')
-        if rocketchat and not ROCKET_CHAT_URL:
-            cls.throw_missing_error('ROCKET_CHAT_URL')
+        if self.github and not self.github_token:
+            self.throw_missing_error('github_token')
+        if self.gitlab and not self.gitlab_token:
+            self.throw_missing_error('gitlab_token')
+        if self.discord and not self.discord_url:
+            self.throw_missing_error('discord_url')
+        if self.slack and not self.slack_token:
+            self.throw_missing_error('slack_token')
+        if self.slack and not self.slack_channel:
+            self.throw_missing_error('slack_channel')
+        if self.rocketchat and not self.rocketchat_url:
+            self.throw_missing_error('rocketchat_url')
 
-    @classmethod
-    def throw_missing_error(cls, missing):
-        """Raise an error based on what env variables
-        are missing.
-        """
+    @staticmethod
+    def throw_missing_error(missing):
+        """Raise an error based on what env variables are missing."""
         message = f'No {missing} set. Please correct and try again.'
         LOGGER.critical(message)
         raise ValueError(message)

--- a/pullbug/github_bug.py
+++ b/pullbug/github_bug.py
@@ -1,68 +1,91 @@
 import logging
-import os
 
 import requests
 
 from pullbug.logger import PullBugLogger
 from pullbug.messages import Messages
 
-GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
-GITHUB_HEADERS = {
-    'Authorization': f'token {GITHUB_TOKEN}',
-    'Content-Type': 'application/json; charset=utf-8',
-}
 LOGGER = logging.getLogger(__name__)
 
 
 class GithubBug:
-    @classmethod
-    def run(
-        cls,
+    def __init__(
+        self,
+        github_token=None,
         github_owner=None,
         github_state='open',
         github_context='orgs',
         wip=False,
         discord=False,
+        discord_url=None,
         slack=False,
+        slack_token=None,
+        slack_channel=None,
         rocketchat=False,
+        rocketchat_url=None,
     ):
+        # Parameter variables
+        self.github_token = github_token
+        self.github_owner = github_owner
+        self.github_state = github_state
+        self.github_context = github_context
+        self.wip = wip
+        self.discord = discord
+        self.discord_url = discord_url
+        self.slack = slack
+        self.slack_token = slack_token
+        self.slack_channel = slack_channel
+        self.rocketchat = rocketchat
+        self.rocketchat_url = rocketchat_url
+
+        # Internal variables
+        self.github_headers = {
+            'Authorization': f'token {self.github_token}',
+            'Content-Type': 'application/json; charset=utf-8',
+        }
+
+    def run(self):
         """Run the logic to get PR's from GitHub and
         send that data via message.
         """
         PullBugLogger._setup_logging(LOGGER)
-        repos = cls.get_repos(github_owner, github_context)
-        pull_requests = cls.get_pull_requests(repos, github_owner, github_state)
+        repos = self.get_repos()
+        pull_requests = self.get_pull_requests(repos)
 
         if pull_requests == []:
             message = 'No pull requests are available from GitHub.'
             LOGGER.info(message)
 
-            return message
+            return message  # TODO: Don't return early here, handle this better
 
         message_preamble = '\n:bug: *The following pull requests on GitHub are still open and need your help!*\n'
-        messages, discord_messages = cls.iterate_pull_requests(pull_requests, wip, discord, slack, rocketchat)
+        messages, discord_messages = self.iterate_pull_requests(pull_requests)
         messages.insert(0, message_preamble)
         discord_messages.insert(0, message_preamble)
-        if discord:
+
+        if self.discord:
             Messages.send_discord_message(discord_messages)
-        if slack:
+        if self.slack:
             Messages.send_slack_message(messages)
-        if rocketchat:
+        if self.rocketchat:
             Messages.send_rocketchat_message(messages)
         LOGGER.info(messages)
 
-    @classmethod
-    def get_repos(cls, github_owner, github_context=''):
+    def get_repos(self):
         """Get all repos of the github_owner."""
         LOGGER.info('Bugging GitHub for repos...')
         try:
             response = requests.get(
-                f'https://api.github.com/{github_context}/{github_owner}/repos?per_page=100', headers=GITHUB_HEADERS
+                f'https://api.github.com/{self.github_context}/{self.github_owner}/repos?per_page=100',
+                headers=self.github_headers,
             )
             LOGGER.debug(response.text)
             LOGGER.info('GitHub repos retrieved!')
             if 'Not Found' in response.text:
-                error = f'Could not retrieve GitHub repos due to bad parameter: {github_owner} | {github_context}.'
+                error = (
+                    f'Could not retrieve GitHub repos due to bad parameter: {self.github_owner} |'
+                    f' {self.github_context}.'
+                )
                 LOGGER.error(error)
                 raise ValueError(error)
         except requests.exceptions.RequestException as response_error:
@@ -71,16 +94,15 @@ class GithubBug:
 
         return response.json()
 
-    @classmethod
-    def get_pull_requests(cls, repos, github_owner, github_state):
+    def get_pull_requests(self, repos):
         """Grab all pull requests from each repo."""
         LOGGER.info('Bugging GitHub for pull requests...')
         pull_requests = []
         for repo in repos:
             try:
                 pull_response = requests.get(
-                    f'https://api.github.com/repos/{github_owner}/{repo["name"]}/pulls?state={github_state}&per_page=100',  # noqa
-                    headers=GITHUB_HEADERS,
+                    f'https://api.github.com/repos/{self.github_owner}/{repo["name"]}/pulls?state={self.github_state}&per_page=100',  # noqa
+                    headers=self.github_headers,
                 )
                 if pull_response and pull_response.json():
                     LOGGER.debug(pull_response.text)
@@ -94,7 +116,8 @@ class GithubBug:
                 raise requests.exceptions.RequestException(response_error)
             except TypeError:
                 error = (
-                    f'Could not retrieve GitHub pull requests due to bad parameter: {github_owner} | {github_state}.'
+                    f'Could not retrieve GitHub pull requests due to bad parameter: {self.github_owner} |'
+                    f' {self.github_state}.'
                 )
                 LOGGER.error(error)
                 raise TypeError(error)
@@ -102,18 +125,19 @@ class GithubBug:
 
         return pull_requests
 
-    @classmethod
-    def iterate_pull_requests(cls, pull_requests, wip, discord, slack, rocketchat):
+    def iterate_pull_requests(self, pull_requests):
         """Iterate through each pull request of a repo
         and build the message array.
         """
         message_array = []
         discord_message_array = []
         for pull_request in pull_requests:
-            if not wip and 'WIP' in pull_request['title'].upper():
+            if not self.wip and 'WIP' in pull_request['title'].upper():
                 continue
             else:
-                message, discord_message = Messages.prepare_github_message(pull_request, discord, slack, rocketchat)
+                message, discord_message = Messages.prepare_github_message(
+                    pull_request, self.discord, self.slack, self.rocketchat
+                )
                 message_array.append(message)
                 discord_message_array.append(discord_message)
 

--- a/pullbug/gitlab_bug.py
+++ b/pullbug/gitlab_bug.py
@@ -1,28 +1,48 @@
 import logging
-import os
 
 import requests
 
 from pullbug.logger import PullBugLogger
 from pullbug.messages import Messages
 
-GITLAB_API_KEY = os.getenv('GITLAB_API_KEY')
-GITLAB_API_URL = os.getenv('GITLAB_API_URL', 'https://gitlab.com/api/v4')
-IGNORE_WIP = os.getenv('IGNORE_WIP')
-GITLAB_HEADERS = {
-    'authorization': f'Bearer {GITLAB_API_KEY}',
-}
 LOGGER = logging.getLogger(__name__)
 
 
 class GitlabBug:
-    @classmethod
-    def run(cls, gitlab_scope='all', gitlab_state='opened', wip=False, discord=False, slack=False, rocketchat=False):
-        """Run the logic to get MR's from GitLab and
-        send that data via message.
-        """
+    def __init__(
+        self,
+        gitlab_token=None,
+        gitlab_url='https://gitlab.com/api/v4',
+        gitlab_state='opened',
+        gitlab_scope='all',
+        wip=False,
+        discord=False,
+        discord_url=None,
+        slack=False,
+        slack_token=None,
+        slack_channel=None,
+        rocketchat=False,
+        rocketchat_url=None,
+    ):
+        # Parameter variables
+        self.gitlab_token = gitlab_token
+        self.gitlab_url = gitlab_url
+        self.gitlab_state = gitlab_state
+        self.gitlab_scope = gitlab_scope
+        self.wip = wip
+        self.discord = discord
+        self.discord_url = discord_url
+        self.slack = slack
+        self.slack_token = slack_token
+        self.slack_channel = slack_channel
+        self.rocketchat = rocketchat
+        self.rocketchat_url = rocketchat_url
+
+    @staticmethod
+    def run(self):
+        """Run the logic to get MR's from GitLab and send that data via message."""
         PullBugLogger._setup_logging(LOGGER)
-        merge_requests = cls.get_merge_requests(gitlab_scope, gitlab_state)
+        merge_requests = self.get_merge_requests(self.gitlab_scope, self.gitlab_state)
 
         if merge_requests == []:
             message = 'No merge requests are available from GitLab.'
@@ -30,31 +50,36 @@ class GitlabBug:
             return message
 
         message_preamble = '\n:bug: *The following merge requests on GitLab are still open and need your help!*\n'
-        messages, discord_messages = cls.iterate_merge_requests(merge_requests, wip, discord, slack, rocketchat)
+        messages, discord_messages = self.iterate_merge_requests(
+            merge_requests, self.wip, self.discord, self.slack, self.rocketchat
+        )
         messages.insert(0, message_preamble)
         discord_messages.insert(0, message_preamble)
-        if discord:
+        if self.discord:
             Messages.send_discord_message(discord_messages)
-        if slack:
+        if self.slack:
             Messages.send_slack_message(messages)
-        if rocketchat:
+        if self.rocketchat:
             Messages.send_rocketchat_message(messages)
         LOGGER.info(messages)
 
-    @classmethod
-    def get_merge_requests(cls, gitlab_scope, gitlab_state):
+    @staticmethod
+    def get_merge_requests(self):
         """Get all repos of the GITLAB_API_URL."""
         LOGGER.info('Bugging GitLab for merge requests...')
         try:
             response = requests.get(
-                f"{GITLAB_API_URL}/merge_requests?scope={gitlab_scope}&state={gitlab_state}&per_page=100",
-                headers=GITLAB_HEADERS,
+                f"{self.gitlab_url}/merge_requests?scope={self.gitlab_scope}&state={self.gitlab_state}&per_page=100",
+                headers={
+                    'authorization': f'Bearer {self.gitlab_token}',
+                },
             )
             LOGGER.debug(response.text)
             LOGGER.info('GitLab merge requests retrieved!')
             if 'does not have a valid value' in response.text:
                 error = (
-                    f'Could not retrieve GitLab merge requests due to bad parameter: {gitlab_scope} | {gitlab_state}.'
+                    f'Could not retrieve GitLab merge requests due to bad parameter: {self.gitlab_scope} |'
+                    f' {self.gitlab_state}.'
                 )
                 LOGGER.error(error)
                 raise ValueError(error)
@@ -64,20 +89,20 @@ class GitlabBug:
 
         return response.json()
 
-    @classmethod
-    def iterate_merge_requests(cls, merge_requests, wip, discord, slack, rocketchat):
-        """Iterate through each merge request of a repo
-        and build the message array.
-        """
+    @staticmethod
+    def iterate_merge_requests(self, merge_requests):
+        """Iterate through each merge request of a repo and build the message array."""
         message_array = []
         discord_message_array = []
         for merge_request in merge_requests:
             # TODO: There is a "work_in_progress" key in the response
             # that could be used? https://docs.gitlab.com/ee/api/merge_requests.html
-            if not wip and 'WIP' in merge_request['title'].upper():
+            if not self.wip and 'WIP' in merge_request['title'].upper():
                 continue
             else:
-                message, discord_message = Messages.prepare_gitlab_message(merge_request, discord, slack, rocketchat)
+                message, discord_message = Messages.prepare_gitlab_message(
+                    merge_request, self.discord, self.slack, self.rocketchat
+                )
                 message_array.append(message)
                 discord_message_array.append(discord_message)
 

--- a/pullbug/logger.py
+++ b/pullbug/logger.py
@@ -2,20 +2,19 @@ import logging
 import logging.handlers
 import os
 
-PULLBUG_LOCATION = os.path.expanduser(os.getenv('PULLBUG_LOCATION', '~/pullbug'))
-LOG_PATH = os.path.join(PULLBUG_LOCATION, 'logs')
-LOG_FILE = os.path.join(LOG_PATH, 'pullbug.log')
-
 
 class PullBugLogger:
-    @classmethod
-    def _setup_logging(cls, logger):
+    def _setup_logging(self, logger):
         """Setup project logging (to console and log file)."""
-        if not os.path.exists(LOG_PATH):
-            os.makedirs(LOG_PATH)
+        log_path = os.path.join(self.location, 'logs')
+        log_file = os.path.join(log_path, 'pullbug.log')
+
+        if not os.path.exists(log_path):
+            os.makedirs(log_path)
+
         logger.setLevel(logging.INFO)
         handler = logging.handlers.RotatingFileHandler(
-            LOG_FILE,
+            log_file,
             maxBytes=200000,
             backupCount=5,
         )

--- a/pullbug/messages.py
+++ b/pullbug/messages.py
@@ -1,22 +1,16 @@
 import logging
 import math
-import os
 import re
 
 import requests
 import slack
 
-DISCORD_WEBHOOK_URL = os.getenv('DISCORD_WEBHOOK_URL')
-ROCKET_CHAT_URL = os.getenv('ROCKET_CHAT_URL')
-SLACK_BOT_TOKEN = os.getenv('SLACK_BOT_TOKEN')
-SLACK_CHANNEL = os.getenv('SLACK_CHANNEL')
-GITLAB_API_URL = os.getenv('GITLAB_API_URL', 'https://gitlab.com/api/v4')
 LOGGER = logging.getLogger(__name__)
 
 
 class Messages:
-    @classmethod
-    def send_discord_message(cls, message):
+    @staticmethod
+    def send_discord_message(self, message):
         """Send a Discord message.
 
         Discord has a hard limit of 2000 characters per message,
@@ -34,39 +28,39 @@ class Messages:
             new_cutoff += max_per_batch
             old_cutoff += max_per_batch
             try:
-                requests.post(DISCORD_WEBHOOK_URL, json={'content': batch_message})
+                requests.post(self.discord_url, json={'content': batch_message})
                 LOGGER.info('Discord message sent!')
             except requests.exceptions.RequestException as discord_error:
                 LOGGER.error(f'Could not send Discord message: {discord_error}')
                 raise requests.exceptions.RequestException(discord_error)
 
-    @classmethod
-    def send_rocketchat_message(cls, message):
-        """Send a Rocket Chat message
+    @staticmethod
+    def send_rocketchat_message(self, message):
+        """Send a Rocket Chat message.
 
         We truncate the message at 40,000 characters to match Slack
         and improve performance. RC doesn't specify a char limit.
         """
         rocketchat_message = ''.join(message)[:40000]
         try:
-            requests.post(ROCKET_CHAT_URL, json={'text': rocketchat_message})
+            requests.post(self.rocketchat_url, json={'text': rocketchat_message})
             LOGGER.info('Rocket Chat message sent!')
         except requests.exceptions.RequestException as rc_error:
             LOGGER.error(f'Could not send Rocket Chat message: {rc_error}')
             raise requests.exceptions.RequestException(rc_error)
 
-    @classmethod
-    def send_slack_message(cls, message):
+    @staticmethod
+    def send_slack_message(self, message):
         """Send Slack messages via a bot.
 
         Slack truncates messages after 40,000 characters so
         we truncate there before sending the request.
         """
         slack_message = ''.join(message)[:40000]
-        slack_client = slack.WebClient(SLACK_BOT_TOKEN)
+        slack_client = slack.WebClient(self.slack_token)
         try:
             slack_client.chat_postMessage(
-                channel=SLACK_CHANNEL,
+                channel=self.slack_channel,
                 text=slack_message,
             )
             LOGGER.info('Slack message sent!')
@@ -74,8 +68,8 @@ class Messages:
             LOGGER.error(f'Could not send Slack message: {slack_error}')
             raise slack.errors.SlackApiError(slack_error.response["ok"], slack_error.response['error'])
 
-    @classmethod
-    def prepare_github_message(cls, pull_request, discord, slack, rocketchat):
+    @staticmethod
+    def prepare_github_message(self, pull_request, discord, slack, rocketchat):
         """Prepares a GitHub message with a single pull request's data.
         This will then be appended to an array of messages.
 
@@ -86,6 +80,7 @@ class Messages:
         description_max_length = 120
         users = ''
         discord_users = ''
+
         if pull_request.get('assignees'):
             for assignee in pull_request['assignees']:
                 discord_user = f"{assignee['login']} (<{assignee['html_url']}>)"
@@ -113,8 +108,8 @@ class Messages:
 
         return message, discord_message
 
-    @classmethod
-    def prepare_gitlab_message(cls, merge_request, discord, slack, rocketchat):
+    @staticmethod
+    def prepare_gitlab_message(self, merge_request, discord, slack, rocketchat):
         """Prepare a GitLab message with a single merge request's data.
         This will then be appended to an array of messages.
 
@@ -126,6 +121,7 @@ class Messages:
         discord_users = ''
         re_repo_name = re.compile('(?P<group_name>[\\w-]+)/(?P<repo_name>[\\w-]+)!(?P<merge_request_num>\\d+)')
         re_match = re_repo_name.search(merge_request['references']['full'])
+
         if merge_request.get('assignees'):
             for assignee in merge_request['assignees']:
                 user = f"<{assignee['web_url']}|{assignee['username']}>"
@@ -140,15 +136,17 @@ class Messages:
             if len(merge_request['description']) > description_max_length
             else merge_request.get('description')
         )
+        # fmt: off
         message = (
             f"\n:arrow_heading_up: *Merge Request:* <{merge_request['web_url']}|{merge_request['title']}>"
-            f"\n*Repo:* <{GITLAB_API_URL}/{re_match['group_name']}/{re_match['repo_name']}|{re_match['repo_name']}>"
+            f"\n*Repo:* <{self.gitlab_url}/{re_match['group_name']}/{re_match['repo_name']}|{re_match['repo_name']}>"
             f"\n*Description:* {description}\n*Waiting on:* {users}\n"
         )
         discord_message = (
             f"\n:arrow_heading_up: **Pull Request:** {merge_request['title']} (<{merge_request['web_url']}>)"
-            f"\n**Repo:** {re_match['repo_name']} (<{GITLAB_API_URL}/{re_match['group_name']}/{re_match['repo_name']}>)"
+            f"\n**Repo:** {re_match['repo_name']} (<{self.gitlab_url}/{re_match['group_name']}/{re_match['repo_name']}>)"  # noqa
             f"\n**Description:** {description}\n**Waiting on:** {discord_users}\n"
         )
+        # fmt: on
 
         return message, discord_message

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open('README.md', 'r') as fh:
 REQUIREMENTS = [
     'requests == 2.*',
     'slackclient == 2.*',
-    'python-dotenv == 0.19.*',  # TODO: Remove once we convert env variables to CLI args
 ]
 
 DEV_REQUIREMENTS = [


### PR DESCRIPTION
CHANGES

* Replaces all env variables with CLI args for a more uniform experience, various shortcodes for flags were changed or removed as a part of this process (closes #24)
* Replace all `classmethods` with instance or static methods

BUILD

Yes the build isn't passing, I'm going to merge anyway since we are doing a complete overhaul and the tests would need to be rewritten again on the next refactor prior to releasing this.