### PR TITLE
feat: uses requested_reviewers instead of assignees on PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## NEXT RELEASE
 
+* Added the `author` to the messages
+* Switched from `assignees` to `requested reviewers` for the `waiting on` portion of the message
 * Added `base_url` paremeter to specify an enterprise GitHub instance if necessary
 * Reworked the `github_token` logic to allow for better unauthenticated usage when no GitHub token is passed
+* Corrects the `Messages` class name to the singular `Message`
 
 ## v3.2.1 (2022-01-26)
 

--- a/pullbug/__init__.py
+++ b/pullbug/__init__.py
@@ -1,7 +1,7 @@
 from pullbug.github_bug import GithubBug
-from pullbug.messages import Messages
+from pullbug.messages import Message
 
 __all__ = [
     'GithubBug',
-    'Messages',
+    'Message',
 ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,10 +43,6 @@ def mock_pull_request(mock_user, mock_repo):
     mock_pull_request = MagicMock()
     mock_pull_request.title = 'mock-pull-request'
     mock_pull_request.description = 'Mock description'
-    assignee = MagicMock()
-    assignee.login = mock_user
-    assignee.html_url = f'https://github.com/{mock_user}'
-    mock_pull_request.assignees = [assignee]
     mock_pull_request.body = 'Mock body of a pull request.'
     mock_pull_request.html_url = f'https://github.com/{mock_user}/{mock_repo}/pull/1'
     mock_pull_request.base.repo.name = 'mock-repo'

--- a/test/unit/test_github_bug.py
+++ b/test/unit/test_github_bug.py
@@ -206,7 +206,7 @@ def test_iterate_issues():
     # TODO: Assert the message building functions get called
 
 
-@patch('pullbug.github_bug.Messages.send_discord_message')
+@patch('pullbug.github_bug.Message.send_discord_message')
 def test_send_messages_discord(mock_send_discord_message, mock_url):
     messages = discord_messages = []
 
@@ -219,7 +219,7 @@ def test_send_messages_discord(mock_send_discord_message, mock_url):
     mock_send_discord_message.assert_called_once_with(messages, mock_url)
 
 
-@patch('pullbug.github_bug.Messages.send_slack_message')
+@patch('pullbug.github_bug.Message.send_slack_message')
 def test_send_messages_slack(mock_send_slack_message, mock_token, mock_channel):
     messages = discord_messages = []
 
@@ -233,7 +233,7 @@ def test_send_messages_slack(mock_send_slack_message, mock_token, mock_channel):
     mock_send_slack_message.assert_called_once_with(messages, mock_token, mock_channel)
 
 
-@patch('pullbug.github_bug.Messages.send_rocketchat_message')
+@patch('pullbug.github_bug.Message.send_rocketchat_message')
 def test_send_messages_rocketchat(mock_send_rocketchat_message, mock_url):
     messages = discord_messages = []
 

--- a/test/unit/test_messages.py
+++ b/test/unit/test_messages.py
@@ -1,16 +1,16 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 import slack
 
-from pullbug.messages import Messages
+from pullbug.messages import Message
 
 
 @patch('logging.Logger.info')
 @patch('requests.post')
 def test_discord_success(mock_request, mock_logger, mock_url, mock_messages):
-    Messages.send_discord_message(mock_messages, mock_url)
+    Message.send_discord_message(mock_messages, mock_url)
 
     mock_request.assert_called_once_with(mock_url, json={'content': mock_messages[0]})
     mock_logger.assert_called_once_with('Discord message sent!')
@@ -20,7 +20,7 @@ def test_discord_success(mock_request, mock_logger, mock_url, mock_messages):
 @patch('requests.post', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_discord_exception(mock_request, mock_logger, mock_url, mock_messages):
     with pytest.raises(requests.exceptions.RequestException):
-        Messages.send_discord_message(mock_messages, mock_url)
+        Message.send_discord_message(mock_messages, mock_url)
 
     mock_logger.assert_called_once_with('Could not send Discord message: mock-error')
 
@@ -28,7 +28,7 @@ def test_discord_exception(mock_request, mock_logger, mock_url, mock_messages):
 @patch('logging.Logger.info')
 @patch('requests.post')
 def test_rocket_chat_success(mock_request, mock_logger, mock_url, mock_messages):
-    Messages.send_rocketchat_message(mock_messages, mock_url)
+    Message.send_rocketchat_message(mock_messages, mock_url)
 
     mock_request.assert_called_once_with(mock_url, json={'text': mock_messages[0]})
     mock_logger.assert_called_once_with('Rocket Chat message sent!')
@@ -38,7 +38,7 @@ def test_rocket_chat_success(mock_request, mock_logger, mock_url, mock_messages)
 @patch('requests.post', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_rocket_chat_exception(mock_request, mock_logger, mock_url, mock_messages):
     with pytest.raises(requests.exceptions.RequestException):
-        Messages.send_rocketchat_message(mock_messages, mock_url)
+        Message.send_rocketchat_message(mock_messages, mock_url)
 
     mock_logger.assert_called_once_with('Could not send Rocket Chat message: mock-error')
 
@@ -46,7 +46,7 @@ def test_rocket_chat_exception(mock_request, mock_logger, mock_url, mock_message
 @patch('logging.Logger.info')
 @patch('slack.WebClient.chat_postMessage')
 def test_slack_success(mock_slack, mock_logger, mock_messages, mock_token, mock_channel):
-    Messages.send_slack_message(mock_messages, mock_token, mock_channel)
+    Message.send_slack_message(mock_messages, mock_token, mock_channel)
 
     mock_slack.assert_called_once_with(channel='mock-channel', text=mock_messages[0])
     mock_logger.assert_called_once_with('Slack message sent!')
@@ -61,7 +61,7 @@ def test_slack_success(mock_slack, mock_logger, mock_messages, mock_token, mock_
 )
 def test_slack_exception(mock_slack, mock_logger, mock_messages, mock_token, mock_channel):
     with pytest.raises(slack.errors.SlackApiError):
-        Messages.send_slack_message(mock_messages, mock_token, mock_channel)
+        Message.send_slack_message(mock_messages, mock_token, mock_channel)
 
     mock_logger.assert_called_once_with(
         "Could not send Slack message: The request to the Slack API failed.\nThe server responded with: {'ok': False, 'error': 'not_authed'}"  # noqa
@@ -69,28 +69,34 @@ def test_slack_exception(mock_slack, mock_logger, mock_messages, mock_token, moc
 
 
 def test_prepare_pulls_message(mock_pull_request, mock_user, mock_repo):
-    result, discord_result = Messages.prepare_pulls_message(mock_pull_request)
+    reviewer = MagicMock()
+    reviewer.login = mock_user
+    reviewer.html_url = f'https://github.com/{mock_user}'
+    reviewers = [reviewer]
+
+    result, discord_result = Message.prepare_pulls_message(mock_pull_request, reviewers)
 
     # Message
     assert 'Pull Request' in result
-    assert f'{mock_pull_request.assignees[0].html_url}|{mock_pull_request.assignees[0].login}' in result
+    assert '' == result
+    assert f'{reviewers[0].html_url}|{reviewers[0].login}' in result
     assert f'{mock_pull_request.html_url}|{mock_pull_request.title}' in result
 
     # Discord message
     assert 'Pull Request' in discord_result
-    assert f'{mock_pull_request.assignees[0].login} (<{mock_pull_request.assignees[0].html_url}>)' in discord_result
+    assert f'{reviewers[0].login} (<{reviewers[0].html_url}>)' in discord_result
     assert f'{mock_pull_request.title} (<{mock_pull_request.html_url}>)' in discord_result
 
 
 def test_prepare_pulls_message_no_assignee(mock_pull_request):
-    mock_pull_request.assignees = []
-    result, discord_result = Messages.prepare_pulls_message(mock_pull_request)
+    mock_pull_request.requested_reviewers = []
+    result, discord_result = Message.prepare_pulls_message(mock_pull_request, [])
 
-    assert '*Waiting on:* NA' in result
+    assert '*Reviews Requested From:* NA' in result
 
 
 def test_prepare_issues_message(mock_issue, mock_user, mock_repo):
-    result, discord_result = Messages.prepare_issues_message(mock_issue)
+    result, discord_result = Message.prepare_issues_message(mock_issue)
 
     # Message
     assert 'Issue' in result
@@ -105,6 +111,6 @@ def test_prepare_issues_message(mock_issue, mock_user, mock_repo):
 
 def test_prepare_issues_message_no_assignee(mock_issue):
     mock_issue.assignees = []
-    result, discord_result = Messages.prepare_issues_message(mock_issue)
+    result, discord_result = Message.prepare_issues_message(mock_issue)
 
     assert '*Assigned to:* NA' in result

--- a/test/unit/test_messages.py
+++ b/test/unit/test_messages.py
@@ -72,19 +72,18 @@ def test_prepare_pulls_message(mock_pull_request, mock_user, mock_repo):
     reviewer = MagicMock()
     reviewer.login = mock_user
     reviewer.html_url = f'https://github.com/{mock_user}'
-    reviewers = [reviewer]
+    reviewers = [(reviewer, None)]
 
     result, discord_result = Message.prepare_pulls_message(mock_pull_request, reviewers)
 
     # Message
     assert 'Pull Request' in result
-    assert '' == result
-    assert f'{reviewers[0].html_url}|{reviewers[0].login}' in result
+    assert f'{reviewer.html_url}|{reviewer.login}' in result
     assert f'{mock_pull_request.html_url}|{mock_pull_request.title}' in result
 
     # Discord message
     assert 'Pull Request' in discord_result
-    assert f'{reviewers[0].login} (<{reviewers[0].html_url}>)' in discord_result
+    assert f'{reviewer.login} (<{reviewer.html_url}>)' in discord_result
     assert f'{mock_pull_request.title} (<{mock_pull_request.html_url}>)' in discord_result
 
 


### PR DESCRIPTION
* Added the `author` to the messages
* Switched from `assignees` to `requested reviewers` for the `waiting on` portion of the message
* Corrects the `Messages` class name to the singular `Message`